### PR TITLE
checkbox position changed to avoid confusion

### DIFF
--- a/portlets/tip-of-the-day-portlet/docroot/html/dockbar/content.jsp
+++ b/portlets/tip-of-the-day-portlet/docroot/html/dockbar/content.jsp
@@ -58,10 +58,10 @@ boolean showArticleTitle = GetterUtil.getBoolean(request.getAttribute(WebKeys.SH
     <div class="clearfix"></div>
     <br/>
     <div class="tip-buttons">
-        <aui:input name="<%=WebKeys.STOP_SHOWING%>" label="tof-dont-show" type="checkbox" checked="<%= stopShowing %>" cssClass="ajax-checkbox-action" />
         <aui:button name="previous" value='<%= LanguageUtil.get(pageContext, "tof-previous") %>' href="<%= previousURL %>" disabled="<%= disablePrev %>"/>
         <aui:button name="next" value='<%= LanguageUtil.get(pageContext, "tof-next") %>' href="<%= nextURL %>" disabled="<%= disableNext %>" />
         <aui:button name="done" value='<%= LanguageUtil.get(pageContext, "tof-done") %>' cssClass="tofd-close-pop-up"/>
+        <aui:input name="<%=WebKeys.STOP_SHOWING%>" label="tof-dont-show" type="checkbox" checked="<%= stopShowing %>" cssClass="ajax-checkbox-action" />
         <div class="clearfix"></div>
     </div>
     <div class="clearfix"></div>


### PR DESCRIPTION
position of the checkbox changed, because it was unclear if the checkbox was for all the content or only for the current tip